### PR TITLE
Add Docker, Kind, and Minikube support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,6 +23,9 @@
         },
         "ghcr.io/devcontainers/features/kubernetes-tools:1": {
             "version": "latest"
+        },
+        "ghcr.io/devcontainers/features/kind:1": {
+            "version": "latest"
         }
     },
     "customizations": {


### PR DESCRIPTION
I've resolved the merge conflict between the different Kind package sources, choosing the official devcontainers version. I've also standardized on having both Kind and Minikube available.