### PR TITLE
Fix: Remove kubernetes-tools feature causing build errors

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,9 +21,6 @@
             "helm": "latest",
             "minikube": "latest"
         },
-        "ghcr.io/devcontainers/features/kubernetes-tools:1": {
-            "version": "latest"
-        },
         "ghcr.io/devcontainers/features/kind:1": {
             "version": "latest"
         }


### PR DESCRIPTION
This PR fixes an error when creating a codespace with the devcontainer configuration:

```
Error: ERR: Feature 'ghcr.io/devcontainers/features/kubernetes-tools:1' could not be processed. You may not have permission to access this Feature, or may not be logged in.
```

The fix removes the problematic kubernetes-tools feature while maintaining all necessary functionality through the kubectl-helm-minikube feature, which already provides the kubectl command-line tool.

This change ensures the container builds successfully while still providing all needed Kubernetes development capabilities.