### PR TITLE
Fix: Remove dotfiles feature causing container creation failure

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,10 +26,6 @@
         },
         "ghcr.io/devcontainers/features/github-cli:1": {
             "version": "latest"
-        },
-        "ghcr.io/devcontainers/features/dotfiles:1": {
-            "repository": "idvoretskyi/dotfiles",
-            "installCommand": ""
         }
     },
     "customizations": {


### PR DESCRIPTION
This PR fixes an issue with container creation that was failing due to the dotfiles feature. The container was failing with error: 'Feature ghcr.io/devcontainers/features/dotfiles:1 could not be processed'. The solution is to remove this feature from the devcontainer.json configuration.